### PR TITLE
Argument parser has no inputUrl or outputUrl fields

### DIFF
--- a/src/DLStubBuilder.m
+++ b/src/DLStubBuilder.m
@@ -87,7 +87,7 @@ void* %s(void)\n\
 
 
 -(void) generateFilesToOutputFolder {
-    NSURL *outputFolder = _arguments.outputUrl;
+    NSURL *outputFolder = [NSURL fileURLWithPath:_arguments.outputPath];
     NSString *libraryName = _libraryParser.mainImage.imageName;
     _mainIncludeHeader = [[NSMutableArray alloc] init];
     _sourceFileList = [[NSMutableArray alloc] init];

--- a/src/main.m
+++ b/src/main.m
@@ -34,7 +34,7 @@ int main(int argc, const char * argv[]) {
             [dlError terminateProgram];
         }
         
-        MKMemoryMap *memoryMap = [MKMemoryMap memoryMapWithContentsOfFile: argumentParser.inputUrl error:nil];
+        MKMemoryMap *memoryMap = [MKMemoryMap memoryMapWithContentsOfFile:[NSURL fileURLWithPath:argumentParser.inputFile] error:nil];
 //        if (error != nil) {
 //            [error terminateProgram];
 //        }


### PR DESCRIPTION
Relates to #3 

At least this fixes the issue on my end. I'm not well versed in XCode, so it might have something to do with my version/setup? If so, feel free to ignore this PR.